### PR TITLE
Ingest experimental data

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 120
 exclude=.cache,.eggs,.git
+E203 whitespace before ':'
+ignore = E203

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
 exclude=.cache,.eggs,.git
-# E203 whitespace before ':' is incompatible with black
-ignore = E203
+# E203 whitespace before ':' incompatible with black
+# W503 line break before binary operator incompatible with black
+ignore = E203,W503

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 120
 exclude=.cache,.eggs,.git
-E203 whitespace before ':'
+# E203 whitespace before ':' is incompatible with black
 ignore = E203

--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ $ pip install .
 
 Run the parser with the local sample:
 ```sh
-$ parse_training_logs
+$ parse_tc_logs -i samples/<log_file>
+```
+
+Publish data to Weight & Biases:
+```sh
+$ parse_tc_logs -i samples/<log_file> --wandb-project <project> --wandb-group=<group> --wandb-run-name=<run>
+```
+
+Run the parser on a directory containing experiments and publis to Weight & Biases:
+```sh
+$ parse_experiment_dir -d models
 ```
 
 ## Development

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,10 @@ setup(
     install_requires=requirements("requirements.txt"),
     packages=["translations_parser"],
     include_package_data=True,
-    entry_points={"console_scripts": ["parse_training_logs=translations_parser.cli:main"]},
+    entry_points={
+        "console_scripts": [
+            "parse_tc_logs=translations_parser.cli.task_cluster:main",
+            "parse_experiment_dir=translations_parser.cli.experiments:main",
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os.path
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 def requirements(path):
@@ -28,7 +28,7 @@ setup(
     author_email="team@teklia.com",
     python_requires=">=3.10",
     install_requires=requirements("requirements.txt"),
-    packages=["translations_parser"],
+    packages=find_packages(),
     include_package_data=True,
     entry_points={
         "console_scripts": [

--- a/translations_parser/cli/experiments.py
+++ b/translations_parser/cli/experiments.py
@@ -99,7 +99,7 @@ def publish_group_logs(project, group, logs_dir):
         group=group,
         name="group_logs",
     )
-    artifact = wandb.Artifact(name="logs", type="logs")
+    artifact = wandb.Artifact(name=group, type="logs")
     artifact.add_dir(local_path=logs_dir)
     run.log_artifact(artifact)
     run.finish()

--- a/translations_parser/cli/experiments.py
+++ b/translations_parser/cli/experiments.py
@@ -1,0 +1,72 @@
+import argparse
+import logging
+import os
+from itertools import groupby
+from pathlib import Path
+
+from translations_parser.parser import TrainingParser
+from translations_parser.publishers import WandB
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Publish multiple experiments to Weight & Biases")
+    parser.add_argument(
+        "--directory",
+        "-d",
+        help="Path to the experiments directory.",
+        type=Path,
+        default=Path(Path(os.getcwd())),
+    )
+    return parser.parse_args()
+
+
+def parse_experiment(logs_file, project, group, name, tags=[]):
+    with logs_file.open("r") as f:
+        lines = (line.strip() for line in f.readlines())
+    parser = TrainingParser(
+        lines,
+        publishers=[
+            WandB(
+                project=project,
+                name=name,
+                group=group,
+                tags=tags,
+                config={"logs_file": logs_file},
+            )
+        ],
+    )
+    parser.run()
+
+
+def main():
+    args = get_args()
+    directory = args.directory
+    file_groups = {path: list(files) for path, files in groupby(directory.glob("**/*.log"), lambda path: path.parent)}
+    total_count = len(file_groups)
+    # Exclude groups missing valid or train log files
+    file_groups = {
+        path: files
+        for path, files in file_groups.items()
+        if ["train.log", "valid.log"] == sorted(f.name for f in files)
+    }
+    logger.info(f"Reading {len(file_groups)} training data (over {total_count} folders)")
+    prefix = os.path.commonprefix([path.parts for path in file_groups])
+    for path, files in file_groups.items():
+        parents = path.parts[len(prefix) :]
+        if len(parents) < 3:
+            logger.warning(f"Skipping folder {path}: Unexpected folder structure")
+            continue
+        project, group, *name = parents
+        name = "_".join(name)
+        # Parse logs
+        for file in files:
+            try:
+                parse_experiment(file, project, group, name)
+            except Exception as e:
+                logger.error(f"An exception occured parsing {file}: {e}")

--- a/translations_parser/cli/experiments.py
+++ b/translations_parser/cli/experiments.py
@@ -52,7 +52,12 @@ class ExperimentsParser(TrainingParser):
                     continue
                 else:
                     metric = MetricEpoch(up=up)
-                    setattr(metric, metrics_file.stem, value)
+                    setattr(
+                        metric,
+                        # Always prefix metrics to avoid names conflict
+                        f"[metric] {metrics_file.stem}",
+                        value,
+                    )
                     self.training.append(metric)
                     up += 1
         return super().run()

--- a/translations_parser/cli/task_cluster.py
+++ b/translations_parser/cli/task_cluster.py
@@ -28,6 +28,12 @@ def get_args():
         default=None,
     )
     parser.add_argument(
+        "--wandb-artifacts",
+        help="Directory containing training artifacts to publish on Weight & Biases.",
+        type=Path,
+        default=None,
+    )
+    parser.add_argument(
         "--wandb-group",
         help="Add the training run to a Weight & Biases group e.g. by language pair or experiment.",
         default=None,
@@ -68,6 +74,7 @@ def main():
         publishers.append(
             WandB(
                 project=args.wandb_project,
+                artifacts=args.wandb_artifacts,
                 group=args.wandb_group,
                 tags=["cli"],
                 name=args.wandb_run_name,
@@ -80,6 +87,6 @@ def main():
     parser = TrainingParser(
         lines,
         publishers=publishers,
-        # log_filter=task_cluster_log_filter,
+        log_filter=task_cluster_log_filter,
     )
     parser.run()

--- a/translations_parser/cli/task_cluster.py
+++ b/translations_parser/cli/task_cluster.py
@@ -80,6 +80,6 @@ def main():
     parser = TrainingParser(
         lines,
         publishers=publishers,
-        log_filter=task_cluster_log_filter,
+        # log_filter=task_cluster_log_filter,
     )
     parser.run()

--- a/translations_parser/parser.py
+++ b/translations_parser/parser.py
@@ -53,8 +53,9 @@ class TrainingParser:
         self.validation = []
         # Dict mapping (epoch, up) to values parsed on multiple lines
         self._validation_entries = defaultdict(dict)
-        # Marian exection data
+        # Option to read logs directly (skip check for Marian context)
         self.skip_marian_context = skip_marian_context
+        # Marian exection data
         self.version = None
         self.version_hash = None
         self.release_date = None

--- a/translations_parser/parser.py
+++ b/translations_parser/parser.py
@@ -148,7 +148,9 @@ class TrainingParser:
         self.version = version.rstrip(";")
         major, minor = map(int, version.lstrip("v").split(".")[:2])
         if (major, minor) > (MARIAN_MAJOR, MARIAN_MINOR):
-            logger.warning("Parsing logs from a newer version of Marian (> {MARIAN_MAJOR}.{MARIAN_MINOR})")
+            logger.warning(
+                f"Parsing logs from a newer version of Marian ({major}.{minor} > {MARIAN_MAJOR}.{MARIAN_MINOR})"
+            )
 
         # Read Marian execution description on the next lines
         desc = []

--- a/translations_parser/publishers.py
+++ b/translations_parser/publishers.py
@@ -52,8 +52,11 @@ class CSVExport(Publisher):
 
 
 class WandB(Publisher):
-    def __init__(self, project, **extra_kwargs):
+    def __init__(self, project, artifacts=None, artifacts_name="logs", **extra_kwargs):
         self.project = project
+        # Optional path to a directory containing training artifacts
+        self.artifacts = artifacts
+        self.artifacts_name = artifacts_name
         self.extra_kwargs = extra_kwargs
 
     def publish(self, training_log):
@@ -82,6 +85,12 @@ class WandB(Publisher):
         # This will be overwritten in case an unhandled exception occurs
         with (Path(self.wandb.dir) / "output.log").open("w") as f:
             f.write(training_log.logs_str)
+
+        # Publish artifacts
+        if self.artifacts:
+            artifact = wandb.Artifact(name=self.artifacts_name, type=self.artifacts_name)
+            artifact.add_dir(local_path=self.artifacts)
+            self.wandb.log_artifact(artifact)
 
     def close(self):
         self.wandb.finish()

--- a/translations_parser/publishers.py
+++ b/translations_parser/publishers.py
@@ -28,7 +28,7 @@ class CSVExport(Publisher):
         assert output_dir.is_dir(), "Output must be a valid directory"
         self.output_dir = output_dir
 
-    def write_data(output, entries, dataclass):
+    def write_data(self, output, entries, dataclass):
         if not entries:
             logger.warning(f"No {dataclass.__name__} entry, skipping.")
         with open(output, "w") as f:


### PR DESCRIPTION
Adds a script to publish data from the given hierarchy of files:
* Files named `train.log` (e.g. from `models/en-ru/<group>/<run>`) are parsed then pushed to W&B
  * `en-ru` is the name of the project, then runs are grouped by group name (directories just under `en-ru`).
  * Metrics at `models/en-ru/<group>/evaluation/<run>/*` are pushed as artifacts on the run.
  * Files at `logs/en-ru/<group>/*` are pushed as artifacts on a last empty run named `group_logs`.
  
  Examples are visible on https://wandb.ai/teklia/projects