### PR TITLE
Support reading an external process and publish in realtime to W&B

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Run the parser with the local sample:
 $ parse_tc_logs -i samples/<log_file>
 ```
 
+Simulate reading logs from a process:
+```sh
+./samples/simulate_process.py | parse_tc_logs -s
+```
+
 Publish data to Weight & Biases:
 ```sh
 $ parse_tc_logs -i samples/<log_file> --wandb-project <project> --wandb-group=<group> --wandb-run-name=<run>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ parse_tc_logs -i samples/<log_file>
 
 Simulate reading logs from a process:
 ```sh
-./samples/simulate_process.py | parse_tc_logs -s
+./samples/simulate_process.py | parse_tc_logs -s --verbose
 ```
 
 Publish data to Weight & Biases:

--- a/samples/simulate_process.py
+++ b/samples/simulate_process.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from time import sleep
+
+logs_sample = Path(__file__).parent / "KZPjvTEiSmO--BXYpQCNPQ.txt"
+
+with logs_sample.open("r") as f:
+    lines = f.readlines()
+
+for line in lines:
+    print(line, end="", flush=True)
+    sleep(0.01)

--- a/translations_parser/cli/task_cluster.py
+++ b/translations_parser/cli/task_cluster.py
@@ -1,9 +1,10 @@
 import argparse
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path
 
-from translations_parser.parser import TrainingParser
+from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import CSVExport, WandB
 
 
@@ -51,6 +52,14 @@ def get_args():
         help="Use a custom name for the Weight & Biases run.",
         default=None,
     )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        help="Print debug messages.",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+    )
     return parser.parse_args()
 
 
@@ -74,6 +83,10 @@ def task_cluster_log_filter(headers):
 
 def main():
     args = get_args()
+
+    if args.loglevel:
+        logger.setLevel(args.loglevel)
+
     args.output_dir.mkdir(parents=True, exist_ok=True)
     if args.from_stream:
         lines = sys.stdin

--- a/translations_parser/data.py
+++ b/translations_parser/data.py
@@ -34,7 +34,3 @@ class TrainingLog:
     # Dict of log lines indexed by their header (e.g. marian, data, memory)
     logs: dict
     run_date: datetime
-
-    @property
-    def logs_str(self):
-        return "\n".join("".join(f"[{key}] {val}\n" for val in values) for key, values in self.logs.items())

--- a/translations_parser/parser.py
+++ b/translations_parser/parser.py
@@ -11,7 +11,7 @@ from translations_parser.data import TrainingEpoch, TrainingLog, ValidationEpoch
 from translations_parser.publishers import Publisher
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="[%(levelname)s] %(message)s",
 )
 logger = logging.getLogger(__name__)
@@ -133,7 +133,7 @@ class TrainingParser:
                     publisher.handle_validation(validation_epoch)
                 except Exception as e:
                     logger.error(f"Error publishing validation epoch using {publisher.__class__.__name__}: {e}")
-            del entry
+            del self._validation_entries[(epoch, up)]
             return validation_epoch
 
     def _iter_log_entries(self):


### PR DESCRIPTION
Based on #3

Tested with `./samples/simulate_process.py | parse_tc_logs -s -v --wandb-project="test-simulation" --wandb-run-name="simulation"`.

It is possible to observe live publication:
![Screenshot_2023-12-01_14-29-51](https://github.com/mozilla/translations-experiment-tracking/assets/45713745/50af1487-c87f-48e2-a62f-c098c4d71ace)

Results are visible on https://wandb.ai/teklia/test-simulation?workspace=user-rigal